### PR TITLE
Add support for WebKit not playing audio unless it is tied to a user interaction

### DIFF
--- a/src/morse-pro-player-waa.js
+++ b/src/morse-pro-player-waa.js
@@ -44,6 +44,7 @@ export default class MorsePlayerWAA {
         this.frequency = undefined;
         this.startPadding = 0;  // number of ms to wait before playing first note of initial sequence
         this.endPadding = 0;  // number of ms to wait at the end of a sequence before playing the next one (or looping)
+        this.openAudioContext = undefined; // Safari requires user interaction to play audio. You can set this to an audio context opened by user interaction so that morse code can be initiated by non-user events (network or a USB keyer)
 
         this._cTimings = [];
         this._isPlaying = false;
@@ -61,7 +62,7 @@ export default class MorsePlayerWAA {
      * @access: private
      */
     _initialiseAudioNodes() {
-        this.audioContext = new this.audioContextClass();
+        this.audioContext = this.openAudioContext || new this.audioContextClass();
         this.splitterNode = this.audioContext.createGain();  // this node is here to attach other nodes to in subclass
         this.lowPassNode = this.audioContext.createBiquadFilter();
         this.lowPassNode.type = "lowpass";
@@ -235,7 +236,8 @@ export default class MorsePlayerWAA {
             clearInterval(this._timer);
             clearInterval(this._stopTimer);
             clearInterval(this._startTimer);
-            this.audioContext.close();
+            // Don't close the audio context if we have one that was set by the client, since we may not be able to play audio again after that.
+            if (this.openAudioContext == null) this.audioContext.close();
             this.soundStoppedCallback();
         }
     }


### PR DESCRIPTION
Safari won't play audio unless it is initiated as a result of user interaction. I'm working on a web interface for a keyer that I'm building, and the paddle presses get fed to `MorseKeyer` via a websocket. Because these events aren't user initiated Safari won't play any audio for them.

My solution is to add a new property to `MorsePlayerWAA` - `openAudioContext` that can be set from client code. If that variable is set it will be used as the audio context for playing tones, and it won't be closed when the tone finishes playing. 

With this change I can make a button for the user to click to initiate audio from the keyer. In that `onclick` event I can open an audio context and set it on the player.